### PR TITLE
Exit early on non-interactive shells

### DIFF
--- a/shell/mcfly-fzf.bash
+++ b/shell/mcfly-fzf.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Exit early on non-interactive shells
+if ! [[ $- =~ .*i.* ]]; then
+  exit 0
+fi
+
 # Ensure stdin is a tty
 # Avoid loading this file more than once
 if [[ -t 0 ]] && [[ "$__MCFLY_FZF_LOADED" != "loaded" ]]; then
@@ -30,37 +35,33 @@ if [[ -t 0 ]] && [[ "$__MCFLY_FZF_LOADED" != "loaded" ]]; then
     export MCFLY_FZF_OPTS=$(command mktemp ${TMPDIR:-/tmp}/mcfly-fzf.json.XXXXXXXX)
   fi
 
-  # If this is an interactive shell, take ownership of ctrl-r.
-  if [[ $- =~ .*i.* ]]; then
+  # Function to perform ctrl-r binding for fzf. Adapted from junegunn/fzf shell/key-bindings.bash
+  __mcfly_fzf_history__() {
+    local output opts script header strict_ordering
+    strict_ordering="$("$MCFLY_FZF_PATH" toggle "$MCFLY_FZF_OPTS" strict-ordering --view)"
+    opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS
+        --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse
+        --bind=ctrl-r:toggle-sort
+        --bind='ctrl-r:+reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" strict-ordering && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f1:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" sort-order && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f2:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" current-dir-only && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f3:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" exit-code && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --ansi
+        --header-lines 1
+        $FZF_CTRL_R_OPTS +m $strict_ordering"
+    output=$(
+      "$MCFLY_FZF_PATH" dump --header -0 --options-json "$MCFLY_FZF_OPTS" |
+        FZF_DEFAULT_OPTS="$opts" fzf --query "$READLINE_LINE"
+    ) || return
+    READLINE_LINE=${output#*$'\t'}
+    "$MCFLY_FZF_PATH" select -- "$READLINE_LINE"
+    if [[ -z "$READLINE_POINT" ]]; then
+      echo "$READLINE_LINE"
+    else
+      READLINE_POINT=0x7fffffff
+    fi
+  }
 
-    # Function to perform ctrl-r binding for fzf. Adapted from junegunn/fzf shell/key-bindings.bash
-    __mcfly_fzf_history__() {
-      local output opts script header strict_ordering
-      strict_ordering="$("$MCFLY_FZF_PATH" toggle "$MCFLY_FZF_OPTS" strict-ordering --view)"
-      opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS 
-          --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse 
-          --bind=ctrl-r:toggle-sort
-          --bind='ctrl-r:+reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" strict-ordering && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f1:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" sort-order && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f2:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" current-dir-only && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f3:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" exit-code && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --ansi
-          --header-lines 1
-          $FZF_CTRL_R_OPTS +m $strict_ordering"
-      output=$(
-        "$MCFLY_FZF_PATH" dump --header -0 --options-json "$MCFLY_FZF_OPTS" |
-          FZF_DEFAULT_OPTS="$opts" fzf --query "$READLINE_LINE"
-      ) || return
-      READLINE_LINE=${output#*$'\t'}
-      "$MCFLY_FZF_PATH" select -- "$READLINE_LINE"
-      if [[ -z "$READLINE_POINT" ]]; then
-        echo "$READLINE_LINE"
-      else
-        READLINE_POINT=0x7fffffff
-      fi
-    }
-
-    bind -x '"\C-r": __mcfly_fzf_history__'
-  fi
+  bind -x '"\C-r": __mcfly_fzf_history__'
 
 fi

--- a/shell/mcfly-fzf.fish
+++ b/shell/mcfly-fzf.fish
@@ -3,7 +3,7 @@
 # Exit early on non-interactive shells
 if not status is-interactive
   exit 0
-fi
+end
 
 # Ensure mcfly is initialized first
 if not set -q MCFLY_SESSION_ID

--- a/shell/mcfly-fzf.fish
+++ b/shell/mcfly-fzf.fish
@@ -1,5 +1,10 @@
 #!/usr/bin/env fish
 
+# Exit early on non-interactive shells
+if not status is-interactive
+  exit 0
+fi
+
 # Ensure mcfly is initialized first
 if not set -q MCFLY_SESSION_ID
   echo "Mcfly-fzf: Must initialize mcfly before mcfly-fzf"
@@ -30,35 +35,31 @@ if test "$__MCFLY_FZF_LOADED" != "loaded"
   # MCFLY_SESSION_ID is used by McFly internally to keep track of the commands from a particular terminal session.
   set -gx MCFLY_FZF_OPTS (mktemp "$tmpdir/mcfly-fzf.json.XXXXXXXX")
 
-  # If this is an interactive shell, set up key binding functions.
-  if status is-interactive
-    # Adapted from junegunn/fzf shell/key-bindings.fish
-    function __mcfly-fzf-history-widget -d "Search command history with McFly (using fzf)"
-      test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
-      begin
-        set -lx strict_ordering ("$MCFLY_FZF_PATH" toggle "$MCFLY_FZF_OPTS" strict-ordering --view)
-        set -lx FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS 
-          --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse 
-          --bind=ctrl-r:toggle-sort 
-          --bind='ctrl-r:+reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" strict-ordering && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f1:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" sort-order && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f2:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" current-dir-only && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f3:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" exit-code && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --ansi
-          --header-lines 1
-          $FZF_CTRL_R_OPTS +m $strict_ordering"
-        eval $MCFLY_FZF_PATH --history-format fish dump --header -0 --options-json $MCFLY_FZF_OPTS | eval fzf -q '(commandline)' | 
-        string replace -r "[^\t]*\t" "" | read -l result
-        and commandline -- $result
-        and eval $MCFLY_FZF_PATH select -- "$result"
-      end
-      commandline -f repaint
+  # Adapted from junegunn/fzf shell/key-bindings.fish
+  function __mcfly-fzf-history-widget -d "Search command history with McFly (using fzf)"
+    test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
+    begin
+      set -lx strict_ordering ("$MCFLY_FZF_PATH" toggle "$MCFLY_FZF_OPTS" strict-ordering --view)
+      set -lx FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS
+        --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse
+        --bind=ctrl-r:toggle-sort
+        --bind='ctrl-r:+reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" strict-ordering && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f1:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" sort-order && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f2:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" current-dir-only && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f3:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" exit-code && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --ansi
+        --header-lines 1
+        $FZF_CTRL_R_OPTS +m $strict_ordering"
+      eval $MCFLY_FZF_PATH --history-format fish dump --header -0 --options-json $MCFLY_FZF_OPTS | eval fzf -q '(commandline)' |
+      string replace -r "[^\t]*\t" "" | read -l result
+      and commandline -- $result
+      and eval $MCFLY_FZF_PATH select -- "$result"
     end
-  
+    commandline -f repaint
+
     bind \cr __mcfly-fzf-history-widget
     if bind -M insert >/dev/null 2>&1
       bind -M insert \cr __mcfly-fzf-history-widget
     end
-
   end
 end

--- a/shell/mcfly-fzf.zsh
+++ b/shell/mcfly-fzf.zsh
@@ -1,5 +1,10 @@
 #!/bin/zsh
 
+# Exit early on non-interactive shells
+if [[ ! -o interactive ]]; then
+  return 0
+fi
+
 # Ensure mcfly is initialized first
 if [[ ! -n "$MCFLY_SESSION_ID" ]]; then
   echo "Mcfly-fzf: Must initialize mcfly before mcfly-fzf"
@@ -13,7 +18,7 @@ if [[ ! -n "$MCFLY_HISTORY_FORMAT" ]]; then
 fi
 
 # Avoid loading this file more than once
-if [[ -o interactive ]] && [[ "$__MCFLY_FZF_LOADED" != "loaded" ]]; then
+if [[ "$__MCFLY_FZF_LOADED" != "loaded" ]]; then
   __MCFLY_FZF_LOADED="loaded"
 
   # Find the mcfly-fzf binary
@@ -42,42 +47,39 @@ if [[ -o interactive ]] && [[ "$__MCFLY_FZF_LOADED" != "loaded" ]]; then
   }
   zshexit_functions+=(mcfly-fzf-exit-logger)
 
-  # If this is an interactive shell, take ownership of ctrl-r.
-  if [[ $- =~ .*i.* ]]; then
-    # Adapted from junegunn/fzf shell/key-bindings.zsh
-    mcfly-fzf-history-widget() {
-      local selected opts strict_ordering
-      setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
+  # Adapted from junegunn/fzf shell/key-bindings.zsh
+  mcfly-fzf-history-widget() {
+    local selected opts strict_ordering
+    setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
 
-      strict_ordering=$(
-        "$MCFLY_FZF_PATH" toggle "$MCFLY_FZF_OPTS" strict-ordering --view
-      )
-      opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS 
-          --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse 
-          --bind=ctrl-r:toggle-sort 
-          --bind='ctrl-r:+reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" strict-ordering && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f1:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" sort-order && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f2:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" current-dir-only && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --bind='f3:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" exit-code && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")' 
-          --ansi
-          --header-lines 1
-          $FZF_CTRL_R_OPTS +m $strict_ordering"
-      selected=$(
-          $MCFLY_FZF_PATH --history-format $MCFLY_HISTORY_FORMAT dump --header -0 --options-json $MCFLY_FZF_OPTS | FZF_DEFAULT_OPTS="$opts" fzf --query="$LBUFFER"
-      )
+    strict_ordering=$(
+      "$MCFLY_FZF_PATH" toggle "$MCFLY_FZF_OPTS" strict-ordering --view
+    )
+    opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS
+        --nth=2.. --delimiter='\t' --no-hscroll --tiebreak=index --read0 --layout reverse
+        --bind=ctrl-r:toggle-sort
+        --bind='ctrl-r:+reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" strict-ordering && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f1:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" sort-order && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f2:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" current-dir-only && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --bind='f3:reload(\"$MCFLY_FZF_PATH\" toggle \"$MCFLY_FZF_OPTS\" exit-code && \"$MCFLY_FZF_PATH\" dump --header -0 --options-json \"$MCFLY_FZF_OPTS\")'
+        --ansi
+        --header-lines 1
+        $FZF_CTRL_R_OPTS +m $strict_ordering"
+    selected=$(
+        $MCFLY_FZF_PATH --history-format $MCFLY_HISTORY_FORMAT dump --header -0 --options-json $MCFLY_FZF_OPTS | FZF_DEFAULT_OPTS="$opts" fzf --query="$LBUFFER"
+    )
 
-      local ret=$?
-      if [ -n "$selected" ]; then
-          RBUFFER=""
-          LBUFFER="${selected#*$'\t'}"
-          if [ $ret -eq 0 ]; then
-            $MCFLY_FZF_PATH select -- "$LBUFFER"
-          fi
-      fi
-      zle reset-prompt
-      return $ret
-    }
-    zle -N mcfly-fzf-history-widget
-    bindkey '^R' mcfly-fzf-history-widget
-  fi
+    local ret=$?
+    if [ -n "$selected" ]; then
+        RBUFFER=""
+        LBUFFER="${selected#*$'\t'}"
+        if [ $ret -eq 0 ]; then
+          $MCFLY_FZF_PATH select -- "$LBUFFER"
+        fi
+    fi
+    zle reset-prompt
+    return $ret
+  }
+  zle -N mcfly-fzf-history-widget
+  bindkey '^R' mcfly-fzf-history-widget
 fi


### PR DESCRIPTION
This moves any checks for interactive shells to the start of each of the init scripts, and removes all other interactivity checks elsewhere in them. That produces a lot of diff lines because I unindented a big chunk of code, but viewing this diff with whitespace changes hidden is much more reasonable.

I think this fixes #10, though I'm not quite sure how to test mcfly-fzf. If you'd like me to do more testing, let me know and I can figure that out.
